### PR TITLE
Update init script to handle multiple interfaces.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+sie-update (0.3.0) debian-fsi; urgency=low
+
+  * Add support for multiple interfaces to sie-update.
+
+  * Allow INTERFACE to contain multiple interface names.
+
+ -- Chris Mikkelson <cmikk@fsi.io>  Fri, 31 Jul 2015 21:36:02 +0000
+
 sie-update (0.2.0-2) debian-fsi; urgency=medium
 
   * init.d: Notify when INTERFACE not set

--- a/debian/init.d
+++ b/debian/init.d
@@ -27,10 +27,17 @@ fi
 
 . /lib/lsb/init-functions
 
-case "$1" in
+cmd=$1
+
+set -- "$INTERFACE"
+for ifn in $*; do
+	ifopts="$ifopts -i '$ifn'"
+done
+
+case "$cmd" in
   start)
 	log_begin_msg "Starting $DESC:" "$NAME"
-	if start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --name python --startas "$DAEMON" -- -i "$INTERFACE" -d; then
+	if start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --name python --startas "$DAEMON" -- $ifopts -d; then
 	    log_end_msg 0
 	else
 	    log_end_msg 1

--- a/sie-update
+++ b/sie-update
@@ -13,15 +13,11 @@ import tempfile
 import time
 import urllib2
 import urlparse
+import json
 
-URL_BASE = 'http://update.sie-network.net:51080/sie-update/'
-URL_HOSTS = URL_BASE + 'hosts.txt'
-URL_SITES = URL_BASE + 'sites.txt'
-URL_CHANNELS = URL_BASE + 'channels.txt'
+URL_BASE = 'http://update.sie-network.net:51080/sie-update/v2/'
 
-URL_CHALIAS = URL_BASE + 'chalias.%s.txt'
-URL_GRALIAS = URL_BASE + 'gralias.txt'
-URL_OPALIAS = URL_BASE + 'opalias.txt'
+SIE_UPDATE_VERSION = '0.3.0'
 
 FNAME_CHALIAS = 'nmsgtool.chalias'
 FNAME_GRALIAS = 'nmsg.gralias'
@@ -99,7 +95,9 @@ def http_fetch_contents(url, cache_dir=None):
     if VERBOSE:
         print 'Fetching %s...' % url
     try:
-        data = urllib2.urlopen(url).read()
+        req = urllib2.Request(url)
+        req.add_header('User-Agent', 'sie-update/' + SIE_UPDATE_VERSION)
+        data = urllib2.urlopen(req).read()
         if cache_dir:
             cache_put_contents(url, data, cache_dir)
         return data
@@ -125,82 +123,39 @@ def update_file(fname, url, cache_dir=None):
 def do_update(funcs, iface, etcdir):
     cache_dir = get_cache_dir(etcdir, create=True)
     hwaddr = funcs['get_hw_address'](iface)
-    hosts = http_fetch_contents(URL_HOSTS, cache_dir)
-    vlans = set()
-    channels = []
 
-    found_host = False
+    guest_base = urlparse.urljoin(URL_BASE, "guest/")
+    guest_uri = urlparse.urljoin(guest_base, hwaddr.replace(':','-') + ".json")
+
     try:
-        for line in hosts.strip().split('\n'):
-            s = line.split()
-            if hwaddr == s[0]:
-                found_host = True
-                site = s[1]
-                x = s[2]
-                break
+        conf_json = http_fetch_contents(guest_uri, cache_dir)
     except:
-        print >>sys.stderr, 'Error: failed to parse SIE hosts file\n'
-        raise
-
-    if not found_host:
-        print >>sys.stderr, 'Error: hardware address %s not found in SIE hosts file' % hwaddr
+        print >>sys.stderr, 'Error: no SIE configuration found for hardware address %s' % hwaddr
         raise UpdateFailed
-
-    found_site = False
-    sites = http_fetch_contents(URL_SITES, cache_dir)
-    try:
-        for line in sites.strip().split('\n'):
-            s = line.split()
-            s_site = s[0]
-            s_net = s[1]
-            s_vpnnet = s[2]
-            if len(s) >= 4:
-                s_vpnmask = int(s[3])
-            else:
-                s_vpnmask = 24
-            if site == s_site:
-                net = s_net
-                vpnnet = s_vpnnet
-                vpnmask = s_vpnmask
-                found_site = True
-                break
-    except:
-        print >>sys.stderr, 'Error: failed to parse SIE sites file\n'
-        raise
-
-    if not found_site:
-        print >>sys.stderr, 'Error: unknown site %s in SIE hosts file' % site
-        raise Updatefailed
 
     funcs['set_link_up'](iface)
     
     try:
-        for line in http_fetch_contents(URL_CHANNELS, cache_dir).split():
-            line = int(line)
-            channels.append(line)
+        conf = json.loads(conf_json)
     except:
-        print >>sys.stderr, 'Error: failed to parse SIE channels file\n'
+        print >>sys.stderr, 'Error: failed to parse SIE configuration\n'
         raise
 
-    for ch in channels:
-        vlan = ch
-        if vlan == 7:
-            ip = '%s.%s' % (vpnnet, x)
-            funcs['set_vlan_up'](iface, vlan, ip, vpnmask)
-            funcs['set_vlan_mtu'](iface, vlan, 1280)
-        else:
-            ip = '%s.%s.%s' % (net, ch, x)
-            funcs['set_vlan_up'](iface, vlan, ip)
-        vlans.add(vlan)
-
+    vlans = set([c['vlan'] for c in conf['ifconfig']])
     cur_vlans = funcs['get_vlans'](iface)
-    rm_vlans = cur_vlans.difference(vlans)
-    for vlan in rm_vlans:
+    for vlan in cur_vlans.difference(vlans):
         funcs['remove_vlan'](iface, vlan)
+    
+    for c in conf['ifconfig']:
+        funcs['set_vlan_up'](iface, c['vlan'], c['ip'])
 
-    update_file(os.path.join(etcdir, FNAME_CHALIAS), URL_CHALIAS % site, cache_dir)
-    update_file(os.path.join(etcdir, FNAME_GRALIAS), URL_GRALIAS, cache_dir)
-    update_file(os.path.join(etcdir, FNAME_OPALIAS), URL_OPALIAS, cache_dir)
+    url_chalias = urlparse.urljoin(guest_base, conf['files']['chalias'])
+    url_gralias = urlparse.urljoin(guest_base, conf['files']['gralias'])
+    url_opalias = urlparse.urljoin(guest_base, conf['files']['opalias'])
+
+    update_file(os.path.join(etcdir, FNAME_CHALIAS), url_chalias, cache_dir)
+    update_file(os.path.join(etcdir, FNAME_GRALIAS), url_gralias, cache_dir)
+    update_file(os.path.join(etcdir, FNAME_OPALIAS), url_opalias, cache_dir)
 
 def _linux_get_hw_address(iface):
     try:
@@ -277,7 +232,7 @@ def _linux_set_vlan_up(iface, vlan, ip, netmask=24):
     if rc != 0:
         run_cmd('ip link add link %s name %s type vlan id %s' % (iface, vlan_iface, vlan))
         _linux_ip_addr_add(ip, vlan_iface)
-        print 'Added new VLAN %s.' % vlan
+        print 'Added new VLAN %s to %s.' % (vlan, iface)
     else:
         current_ips = set(re.findall('inet ([0-9./]+)', stdout))
         ipnm = '%s/%s' % (ip, netmask)
@@ -300,7 +255,7 @@ def _freebsd_set_vlan_up(iface, vlan, ip, netmask=24):
     if rc != 0:
         run_cmd('ifconfig %s create vlan %s vlandev %s' % (vlan_iface, vlan, iface))
         _freebsd_ip_addr_add(ip, vlan_iface)
-        print 'Added new VLAN %s.' % vlan
+        print 'Added new VLAN %s to %s.' % (vlan, iface)
     else:
         current_ips = set(re.findall('inet ([0-9.]+)', stdout))
         rm_ips = set(current_ips)
@@ -314,11 +269,11 @@ def _freebsd_set_vlan_up(iface, vlan, ip, netmask=24):
 
 def _linux_remove_vlan(iface, vlan):
     run_cmd('ip link del dev %s.%s' % (iface, vlan))
-    print 'Removed old VLAN %s.' % vlan
+    print 'Removed old VLAN %s from %s.' % (vlan, iface)
 
 def _freebsd_remove_vlan(iface, vlan):
     run_cmd('ifconfig vlan%s destroy' % vlan)
-    print 'Removed old VLAN %s.' % vlan
+    print 'Removed old VLAN %s from %s.' % (vlan, iface)
 
 def main():
     global URL_BASE
@@ -345,7 +300,8 @@ def main():
     }
 
     parser = OptionParser('Usage: %prog -i INTERFACE [OPTION]...')
-    parser.add_option('-i', '--interface', dest='interface', help='SIE network interface')
+    parser.add_option('-i', '--interface', dest='interface', action='append',
+        help='SIE network interface')
     parser.add_option('-e', '--etcdir', dest='etcdir', default='/etc',
         help='system configuration directory')
     parser.add_option('-v', '--verbose', dest='verbose', default=VERBOSE,
@@ -385,7 +341,8 @@ def main():
 
     if not opt.daemon:
         try:
-            do_update(net_funcs, opt.interface, opt.etcdir)
+            for iface in opt.interface:
+                do_update(net_funcs, iface, opt.etcdir)
         except UpdateFailed, e:
             sys.exit(1)
     else:
@@ -429,7 +386,8 @@ def main():
 
             while True:
                 try:
-                    do_update(net_funcs, opt.interface, opt.etcdir)
+                    for iface in opt.interface:
+                        do_update(net_funcs, iface, opt.etcdir)
                 except UpdateFailed, e:
                     pass
                 except:


### PR DESCRIPTION
This change allows the /etc/default/sie-update INTERFACE setting to be a space-separated list of interfaces.

It also bumps the version to 0.3.0, matching the versioned User-Agent header in sie-update.