### PR TITLE
Disable ipv6 on Linux interfaces when brought up.

### DIFF
--- a/sie-update
+++ b/sie-update
@@ -231,7 +231,7 @@ def _linux_set_vlan_up(iface, vlan, ip, netmask=24):
     rc, stdout, stderr = run_cmd('ip addr show %s' % vlan_iface, failok=True)
     if rc != 0:
         run_cmd('ip link add link %s name %s type vlan id %s' % (iface, vlan_iface, vlan))
-        run_cmd('sysctl -w net.ipv6.conf.%s/%s.disable_ipv6=1' % (iface, vlan))
+        run_cmd('sysctl -q -w net.ipv6.conf.%s/%s.disable_ipv6=1' % (iface, vlan))
         _linux_ip_addr_add(ip, vlan_iface)
         print 'Added new VLAN %s to %s.' % (vlan, iface)
     else:

--- a/sie-update
+++ b/sie-update
@@ -231,6 +231,7 @@ def _linux_set_vlan_up(iface, vlan, ip, netmask=24):
     rc, stdout, stderr = run_cmd('ip addr show %s' % vlan_iface, failok=True)
     if rc != 0:
         run_cmd('ip link add link %s name %s type vlan id %s' % (iface, vlan_iface, vlan))
+        run_cmd('sysctl -w net.ipv6.conf.%s/%s.disable_ipv6=1' % (iface, vlan))
         _linux_ip_addr_add(ip, vlan_iface)
         print 'Added new VLAN %s to %s.' % (vlan, iface)
     else:


### PR DESCRIPTION
Can't do this on FreeBSD because it's controlled by /etc/rc.conf?